### PR TITLE
Add hooks to enable compiling scss into jar/uberjar

### DIFF
--- a/src/leiningen/scss.clj
+++ b/src/leiningen/scss.clj
@@ -1,14 +1,20 @@
 (ns leiningen.scss
   "Compile an scss project to css using any commandline sass convertion tool."
-  (:require [clojure.java.io :as io]
+  (:require [robert.hooke :as hooke]
+            [clojure.pprint :as p]
+            [clojure.java.io :as io]
             [clojure.java.shell :as shell]
             [clojure.stacktrace :as st]
             [clojure.string :as string]
             [juxt.dirwatch :refer [close-watcher watch-dir]]
             [leiningen.core.main :as lein]
+            [leiningen.compile :as lcompile]
+            [leiningen.clean :as lclean]
+            [leiningen.jar :as ljar]
             [leiningen.scss.config :refer :all]
             [leiningen.scss.helpers :refer :all]
             [leiningen.scss.partials :refer :all]
+            [leiningen.scss.jar :as jar]
             [leiningen.scss.path :refer [abs is-scss-partial? is-scss?]]))
 
 (defn replace-urls
@@ -112,3 +118,17 @@
             (auto project args builds)))
         (do (lein/info (color :bright-white "  Usage: lein scss <build-key ...> [auto|once] [boring] [beep]"))
             (System/exit 1))))))
+
+(defn compile-hook [task & args]
+  (apply task args)
+  (let [project (first args)
+        builds (get-in project [:scss :builds])
+        target (remove (fn [[k v]] (or (nil? (:jar v)) (false? (:jar v)))) builds)]
+    (once (first args) #{} (keys target))))
+
+(defn jar-hook [task & [project out-file filespecs]]
+  (apply task [project out-file (concat filespecs (jar/filespecs project))]))
+
+(defn activate []
+  (hooke/add-hook #'lcompile/compile #'compile-hook)
+  (hooke/add-hook #'ljar/write-jar #'jar-hook))

--- a/src/leiningen/scss.clj
+++ b/src/leiningen/scss.clj
@@ -1,7 +1,6 @@
 (ns leiningen.scss
   "Compile an scss project to css using any commandline sass convertion tool."
   (:require [robert.hooke :as hooke]
-            [clojure.pprint :as p]
             [clojure.java.io :as io]
             [clojure.java.shell :as shell]
             [clojure.stacktrace :as st]

--- a/src/leiningen/scss/jar.clj
+++ b/src/leiningen/scss/jar.clj
@@ -1,0 +1,34 @@
+(ns leiningen.scss.jar
+  (:require [clojure.java.io :as io]
+            [clojure.string :as s]
+            [leiningen.scss.config :as config]))
+
+(defn relative-path [parent child]
+  (let [relative (s/replace child parent "")]
+    (when (= child relative)
+      (throw (Exception. (str child " is not a child of " parent))))
+    (s/replace relative #"^[\\/]" "")))
+
+(defn file-bytes [file]
+  (with-open [input (java.io.FileInputStream. file)]
+    (let [data (byte-array (.length file))]
+      (.read input data)
+      data)))
+
+(defn canonical-path [path]
+  (.getCanonicalPath (io/file path)))
+
+(defn get-files [path]
+  (filter #(not (.isDirectory %)) (file-seq (io/file path))))
+
+(defn filespecs [project]
+  (let [builds (-> project :scss :builds)
+        build-maps (apply dissoc builds (keep #(-> % val (contains? :jar) (if nil (key %))) builds))
+        paths (dedupe (map #(config/dest-dir (val %)) build-maps))]
+    (flatten
+      (for [path paths]
+        (for [file (get-files path)]
+          {:type :bytes
+           :path (relative-path (canonical-path path) (canonical-path file))
+           :bytes (file-bytes file)})))))
+


### PR DESCRIPTION
Leiningen has hook functionality that enable plugins to tie into the
existing tasks of lein. lein-scss seems to be the only scss plugin that does
not leverage this, which is unfortunate since it seems to be the only one
that can use the native libsass library for compilation. This commit should
provide the neccessary hook functions that will expose both compile and jar
tasks to leiningen so that a single call to `lein compile` will output scss
as the project is configured, and calling `lein jar` or `lein uberjar` will
enable adding compiled scss as css to the resulting jarfile.

In order to better suit users, I've added a :jar keyword flag to the build
profile of the scss configuration. Setting this to false will prevent the
process from adding the css into the jarfile.

https://github.com/technomancy/leiningen/blob/master/doc/PLUGINS.md#hooks
